### PR TITLE
iBeacon Advertising

### DIFF
--- a/libraries/javascript/eddystone-advertising/README.md
+++ b/libraries/javascript/eddystone-advertising/README.md
@@ -56,6 +56,8 @@ eddystone.advertisements.forEach(advertisement => {
 <dd></dd>
 <dt><a href="#module_eddystone-url">eddystone-url</a></dt>
 <dd></dd>
+<dt><a href="#module_ibeacon">ibeacon</a></dt>
+<dd></dd>
 <dt><a href="#module_platform">platform</a></dt>
 <dd></dd>
 </dl>
@@ -69,6 +71,7 @@ eddystone.advertisements.forEach(advertisement => {
 </dl>
 
 <a name="module_eddystone-advertisement"></a>
+
 ## eddystone-advertisement
 **Example**  
 ```js
@@ -84,10 +87,14 @@ const advertisement = require('eddystone-advertisement')
         * [.url](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+url) : <code>string</code> &#124; <code>undefined</code>
         * [.namespace](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+namespace) : <code>string</code> &#124; <code>undefined</code>
         * [.instance](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+instance) : <code>string</code> &#124; <code>undefined</code>
+        * [.uuid](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+uuid) : <code>string</code> &#124; <code>undefined</code>
+        * [.major](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+major) : <code>string</code> &#124; <code>undefined</code>
+        * [.minor](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+minor) : <code>string</code> &#124; <code>undefined</code>
         * [.unregisterAdvertisement()](#module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.EddystoneFrameType](#module_eddystone-advertisement.EddystoneFrameType) : <code>enum</code>
 
 <a name="module_eddystone-advertisement.EddystoneAdvertisement"></a>
+
 ### advertisement.EddystoneAdvertisement
 Represents the Advertisement being broadcasted.
 
@@ -101,9 +108,13 @@ Represents the Advertisement being broadcasted.
     * [.url](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+url) : <code>string</code> &#124; <code>undefined</code>
     * [.namespace](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+namespace) : <code>string</code> &#124; <code>undefined</code>
     * [.instance](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+instance) : <code>string</code> &#124; <code>undefined</code>
+    * [.uuid](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+uuid) : <code>string</code> &#124; <code>undefined</code>
+    * [.major](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+major) : <code>string</code> &#124; <code>undefined</code>
+    * [.minor](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+minor) : <code>string</code> &#124; <code>undefined</code>
     * [.unregisterAdvertisement()](#module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
 
 <a name="new_module_eddystone-advertisement.EddystoneAdvertisement_new"></a>
+
 #### new EddystoneAdvertisement(id, options, platform)
 **Throws**:
 
@@ -118,37 +129,62 @@ Represents the Advertisement being broadcasted.
 | platform | <code>Object</code> | The underlying platform; used to unregister the        advertisement. |
 
 <a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+id"></a>
+
 #### eddystoneAdvertisement.id : <code>number</code>
 The ID of this advertisment.
 
 **Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
 <a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+type"></a>
+
 #### eddystoneAdvertisement.type : <code>string</code>
 The Eddystone Type
 
 **Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
 <a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+advertisedTxPower"></a>
+
 #### eddystoneAdvertisement.advertisedTxPower : <code>number</code> &#124; <code>undefined</code>
-Tx Power included in the advertisement. Only present if `type === 'url'`
-         or `type === 'uid'`.
+Tx Power included in the advertisement. Only present if `type === 'url'`,
+         `type === 'uid'`, or `type === 'ibeacon'`.
 
 **Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
 <a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+url"></a>
+
 #### eddystoneAdvertisement.url : <code>string</code> &#124; <code>undefined</code>
 URL being advertised. Only present if `type === 'url'`.
 
 **Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
 <a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+namespace"></a>
+
 #### eddystoneAdvertisement.namespace : <code>string</code> &#124; <code>undefined</code>
 Hex string of the namespace being advertised. Only present if `type === 'uid'`.
 
 **Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
 <a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+instance"></a>
+
 #### eddystoneAdvertisement.instance : <code>string</code> &#124; <code>undefined</code>
 Hex string of the instance being advertised. Only present if `type === 'uid'`.
 
 **Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
+<a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+uuid"></a>
+
+#### eddystoneAdvertisement.uuid : <code>string</code> &#124; <code>undefined</code>
+Hex string of the uuid being advertised. Only present if `type === 'ibeacon'`.
+
+**Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
+<a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+major"></a>
+
+#### eddystoneAdvertisement.major : <code>string</code> &#124; <code>undefined</code>
+Hex string of the major being advertised. Only present if `type === 'ibeacon'`.
+
+**Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
+<a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+minor"></a>
+
+#### eddystoneAdvertisement.minor : <code>string</code> &#124; <code>undefined</code>
+Hex string of the uuid being advertised. Only present if `type === 'ibeacon'`.
+
+**Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
 <a name="module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement"></a>
+
 #### eddystoneAdvertisement.unregisterAdvertisement() ⇒ <code>Promise.&lt;void&gt;</code>
 Unregisters the current advertisement.
 
@@ -158,6 +194,7 @@ Unregisters the current advertisement.
        the promise rejects the advertisment may still be broadcasting. The only
        way to recover may be to reboot your machine.  
 <a name="module_eddystone-advertisement.EddystoneFrameType"></a>
+
 ### advertisement.EddystoneFrameType : <code>enum</code>
 Possible Eddystone frame types.
 
@@ -177,8 +214,10 @@ Possible Eddystone frame types.
 | URL | <code>string</code> | <code>&quot;url&quot;</code> | 
 | UID | <code>string</code> | <code>&quot;uid&quot;</code> | 
 | TLM | <code>string</code> | <code>&quot;tlm&quot;</code> | 
+| IBEACON | <code>string</code> | <code>&quot;ibeacon&quot;</code> | 
 
 <a name="module_eddystone-advertising"></a>
+
 ## eddystone-advertising
 
 * [eddystone-advertising](#module_eddystone-advertising)
@@ -190,12 +229,14 @@ Possible Eddystone frame types.
             * [~EddystoneAdvertisementOptions](#module_eddystone-advertising--Eddystone..EddystoneAdvertisementOptions) : <code>Object</code>
 
 <a name="exp_module_eddystone-advertising--Eddystone"></a>
+
 ### Eddystone ⏏
 Exposes platform independent functions to register/unregister Eddystone
      Advertisements.
 
 **Kind**: Exported class  
 <a name="module_eddystone-advertising--Eddystone.Eddystone+advertisements"></a>
+
 #### eddystone.advertisements : <code>Array.&lt;EddystoneAdvertisement&gt;</code>
 Contains all previously registered advertisements.
 **Note:** In a Chrome App, if the event page gets killed users
@@ -203,6 +244,7 @@ Contains all previously registered advertisements.
 
 **Kind**: instance property of <code>[Eddystone](#exp_module_eddystone-advertising--Eddystone)</code>  
 <a name="module_eddystone-advertising--Eddystone+registerAdvertisement"></a>
+
 #### eddystone.registerAdvertisement() ⇒ <code>Promise.&lt;EddystoneAdvertisement&gt;</code>
 Function to register an Eddystone BLE advertisement.
 
@@ -213,6 +255,7 @@ Function to register an Eddystone BLE advertisement.
        successfully.  
 **Reject**: <code>Error</code> - If the advertisement failed to be registered.  
 <a name="module_eddystone-advertising--Eddystone..EddystoneAdvertisementOptions"></a>
+
 #### Eddystone~EddystoneAdvertisementOptions : <code>Object</code>
 Object that contains the characteristics of the package to advertise.
 
@@ -226,6 +269,7 @@ Object that contains the characteristics of the package to advertise.
 | advertisedTxPower | <code>number</code> &#124; <code>undefined</code> | The Tx Power to advertise |
 
 <a name="module_eddystone-chrome-os"></a>
+
 ## eddystone-chrome-os
 
 * [eddystone-chrome-os](#module_eddystone-chrome-os)
@@ -235,6 +279,7 @@ Object that contains the characteristics of the package to advertise.
         * [._constructAdvertisement()](#module_eddystone-chrome-os--EddystoneChromeOS._constructAdvertisement) ⇒ <code>ChromeOSAdvertisement</code>
 
 <a name="exp_module_eddystone-chrome-os--EddystoneChromeOS"></a>
+
 ### EddystoneChromeOS ⏏
 This class wraps the underlying ChromeOS BLE Advertising API.
 
@@ -244,6 +289,7 @@ This class wraps the underlying ChromeOS BLE Advertising API.
 - [ ] Add link to API.
 
 <a name="module_eddystone-chrome-os--EddystoneChromeOS.registerAdvertisement"></a>
+
 #### EddystoneChromeOS.registerAdvertisement(options) ⇒ <code>Promise.&lt;EddystoneAdvertisement&gt;</code>
 Function that registers an Eddystone BLE advertisement.
 
@@ -257,6 +303,7 @@ Function that registers an Eddystone BLE advertisement.
 | options | <code>EddystoneAdvertisementOptions</code> | The characteristics of the        advertisement. |
 
 <a name="module_eddystone-chrome-os--EddystoneChromeOS.unregisterAdvertisement"></a>
+
 #### EddystoneChromeOS.unregisterAdvertisement(advertisement) ⇒ <code>Promise.&lt;void&gt;</code>
 Function to unregister an advertisement.
 
@@ -269,6 +316,7 @@ Function to unregister an advertisement.
 | advertisement | <code>EddystoneAdvertisement</code> | The advertisement to        unregister. |
 
 <a name="module_eddystone-chrome-os--EddystoneChromeOS._constructAdvertisement"></a>
+
 #### EddystoneChromeOS._constructAdvertisement() ⇒ <code>ChromeOSAdvertisement</code>
 Construct the ChromeOS specific advertisement to register.
 
@@ -289,6 +337,7 @@ Construct the ChromeOS specific advertisement to register.
 **Params**: <code>EddystoneAdvertisementOptions</code> options The characteristics of the
        advertisement.  
 <a name="module_eddystone-uid"></a>
+
 ## eddystone-uid
 
 * [eddystone-uid](#module_eddystone-uid)
@@ -297,12 +346,14 @@ Construct the ChromeOS specific advertisement to register.
         * [.getByteArray(value)](#module_eddystone-uid--EddystoneUID.getByteArray) ⇒ <code>Array.&lt;number&gt;</code>
 
 <a name="exp_module_eddystone-uid--EddystoneUID"></a>
+
 ### EddystoneUID ⏏
 This class provides helper functions that relate to Eddystone-UID.
 
 **Kind**: Exported class  
 **See**: [Eddystone-UID](https://github.com/google/eddystone/tree/master/eddystone-uid)  
 <a name="module_eddystone-uid--EddystoneUID.constructServiceData"></a>
+
 #### EddystoneUID.constructServiceData(advertisedTxPower, namespace, instance) ⇒ <code>Array.&lt;number&gt;</code>
 Constructs a valid Eddystone-UID service data from a Tx Power value, namespace
        and instance.
@@ -318,6 +369,7 @@ Constructs a valid Eddystone-UID service data from a Tx Power value, namespace
 | instance | <code>Array.&lt;number&gt;</code> &#124; <code>string</code> | The instance to advertise. |
 
 <a name="module_eddystone-uid--EddystoneUID.getByteArray"></a>
+
 #### EddystoneUID.getByteArray(value) ⇒ <code>Array.&lt;number&gt;</code>
 Validates the give array of bytes or converts the hex string into an array of bytes.
 
@@ -334,6 +386,7 @@ Validates the give array of bytes or converts the hex string into an array of by
 | value | <code>Array.&lt;number&gt;</code> &#124; <code>string</code> | The value to encode. |
 
 <a name="module_eddystone-url"></a>
+
 ## eddystone-url
 
 * [eddystone-url](#module_eddystone-url)
@@ -342,12 +395,14 @@ Validates the give array of bytes or converts the hex string into an array of by
         * [.encodeURL(url)](#module_eddystone-url--EddystoneURL.encodeURL) ⇒ <code>Array.&lt;number&gt;</code>
 
 <a name="exp_module_eddystone-url--EddystoneURL"></a>
+
 ### EddystoneURL ⏏
 This class provides helper functions that relate to Eddystone-URL.
 
 **Kind**: Exported class  
 **See**: [Eddystone-URL](https://github.com/google/eddystone/tree/master/eddystone-url)  
 <a name="module_eddystone-url--EddystoneURL.constructServiceData"></a>
+
 #### EddystoneURL.constructServiceData(url, advertisedTxPower) ⇒ <code>Array.&lt;number&gt;</code>
 Constructs a valid Eddystone-URL service data from a URL and a Tx Power
        value.
@@ -362,6 +417,7 @@ Constructs a valid Eddystone-URL service data from a URL and a Tx Power
 | advertisedTxPower | <code>number</code> | The Tx Power to use in the service data. |
 
 <a name="module_eddystone-url--EddystoneURL.encodeURL"></a>
+
 #### EddystoneURL.encodeURL(url) ⇒ <code>Array.&lt;number&gt;</code>
 Encodes the given string using the encoding defined in the Eddystone-URL
        Spec.
@@ -383,9 +439,59 @@ Encodes the given string using the encoding defined in the Eddystone-URL
 | --- | --- | --- |
 | url | <code>string</code> | The url to encode. |
 
+<a name="module_ibeacon"></a>
+
+## ibeacon
+
+* [ibeacon](#module_ibeacon)
+    * [IBeacon](#exp_module_ibeacon--IBeacon) ⏏
+        * [.constructManufacturerData(advertisedTxPower, uuid, major, minor)](#module_ibeacon--IBeacon.constructManufacturerData) ⇒ <code>Array.&lt;number&gt;</code>
+        * [.getByteArray(value)](#module_ibeacon--IBeacon.getByteArray) ⇒ <code>Array.&lt;number&gt;</code>
+
+<a name="exp_module_ibeacon--IBeacon"></a>
+
+### IBeacon ⏏
+This class provides helper functions that relate to iBeacon.
+
+**Kind**: Exported class  
+<a name="module_ibeacon--IBeacon.constructManufacturerData"></a>
+
+#### IBeacon.constructManufacturerData(advertisedTxPower, uuid, major, minor) ⇒ <code>Array.&lt;number&gt;</code>
+Constructs a valid iBeacon manufacturer data from a Tx Power value, uuid,
+       major and minor.
+
+**Kind**: static method of <code>[IBeacon](#exp_module_ibeacon--IBeacon)</code>  
+**Returns**: <code>Array.&lt;number&gt;</code> - The manufacturer data.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| advertisedTxPower | <code>number</code> | The Tx Power included in the service data. |
+| uuid | <code>Array.&lt;number&gt;</code> &#124; <code>string</code> | The uuid to advertise. |
+| major | <code>Array.&lt;number&gt;</code> &#124; <code>number</code> | The major to advertise. |
+| minor | <code>Array.&lt;number&gt;</code> &#124; <code>number</code> | The minor to advertise. |
+
+<a name="module_ibeacon--IBeacon.getByteArray"></a>
+
+#### IBeacon.getByteArray(value) ⇒ <code>Array.&lt;number&gt;</code>
+Validates the given array of bytes or converts the hex string into an array of bytes.
+
+**Kind**: static method of <code>[IBeacon](#exp_module_ibeacon--IBeacon)</code>  
+**Returns**: <code>Array.&lt;number&gt;</code> - Array of bytes.  
+**Throws**:
+
+- <code>TypeError</code> If |value| is not an array or a string.
+- <code>Error</code> If |value| contains out-of-range numbers or characters.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| value | <code>Array.&lt;number&gt;</code> &#124; <code>string</code> | The value to encode. |
+
 <a name="module_platform"></a>
+
 ## platform
 <a name="exp_module_platform--platform"></a>
+
 ### platform() ⇒ <code>Object</code> ⏏
 Detects what API is available in the platform.
 
@@ -397,6 +503,7 @@ Detects what API is available in the platform.
 - <code>Error</code> If the platform is unsupported
 
 <a name="eddystone"></a>
+
 ## eddystone : <code>[Eddystone](#exp_module_eddystone-advertising--Eddystone)</code>
 The global eddystone instance.
 

--- a/libraries/javascript/eddystone-advertising/eddystone-advertising.js
+++ b/libraries/javascript/eddystone-advertising/eddystone-advertising.js
@@ -22,7 +22,8 @@
   const EddystoneFrameType = {
     URL: 'url',
     UID: 'uid',
-    TLM: 'tlm'
+    TLM: 'tlm',
+    IBEACON: 'ibeacon'
   };
 
   /**
@@ -33,6 +34,15 @@
      @alias module:eddystone-advertisement.EDDYSTONE_UUID
    */
   const EDDYSTONE_UUID = 'FEAA';
+
+  /**
+     Assigned ID for iBeacon Advertisements
+     @private
+     @constant {string}
+     @default
+     @alias module:eddystone-advertisement.IBEACON_ID
+   */
+  const IBEACON_ID = '004C';
 
   /**
      Represents the Advertisement being broadcasted.
@@ -65,8 +75,8 @@
        */
       this.type = undefined;
       /**
-         Tx Power included in the advertisement. Only present if `type === 'url'`
-         or `type === 'uid'`.
+         Tx Power included in the advertisement. Only present if `type === 'url'`,
+         `type === 'uid'`, or `type === 'ibeacon'`.
          @type {number|undefined}
        */
       this.advertisedTxPower = undefined;
@@ -85,6 +95,21 @@
          @type {string|undefined}
       */
       this.instance = undefined;
+      /**
+         Hex string of the uuid being advertised. Only present if `type === 'ibeacon'`.
+         @type {string|undefined}
+      */
+      this.uuid = undefined;
+      /**
+         Hex string of the major being advertised. Only present if `type === 'ibeacon'`.
+         @type {string|undefined}
+      */
+      this.major = undefined;
+      /**
+         Hex string of the uuid being advertised. Only present if `type === 'ibeacon'`.
+         @type {string|undefined}
+      */
+      this.minor = undefined;
 
       if (options.type == EddystoneFrameType.URL) {
         this.id = id;
@@ -97,6 +122,13 @@
         this.advertisedTxPower = options.advertisedTxPower;
         this.namespace = options.namespace;
         this.instance = options.instance;
+      } else if (options.type == EddystoneFrameType.IBEACON) {
+        this.id = id;
+        this.type = options.type;
+        this.advertisedTxPower = options.advertisedTxPower;
+        this.uuid = options.uuid;
+        this.major = options.major;
+        this.minor = options.minor;
       } else {
         throw new Error('Unsupported Frame Type');
       }
@@ -118,6 +150,7 @@
   exports.EddystoneAdvertisement = EddystoneAdvertisement;
   exports.EddystoneFrameType = EddystoneFrameType;
   exports.EDDYSTONE_UUID = EDDYSTONE_UUID;
+  exports.IBEACON_ID = IBEACON_ID;
 })();
 
 },{}],2:[function(require,module,exports){
@@ -197,6 +230,8 @@
         Eddystone._checkURLOptions(options);
       } else if (options.type === EddystoneFrameType.UID) {
         Eddystone._checkUIDOptions(options);
+      } else if (options.type === EddystoneFrameType.IBEACON) {
+        Eddystone._checkIBEACONOptions(options);
       } else {
         throw new TypeError('Unsupported Frame Type: ' + options.type);
       }
@@ -228,12 +263,26 @@
         throw new TypeError('Required member instance is undefined.');
       }
     }
+    static _checkIBEACONOptions(options) {
+      if (!('advertisedTxPower' in options)) {
+        throw new TypeError('Required member advertisedTxPower is undefined.');
+      }
+      if (!('uuid' in options)) {
+        throw new TypeError('Required member uuid is undefined.');
+      }
+      if (!('major' in options)) {
+        throw new TypeError('Required member major is undefined.');
+      }
+      if (!('minor' in options)) {
+        throw new TypeError('Required member minor is undefined.');
+      }
+    }
   }
 
   module.exports = Eddystone;
 })();
 
-},{"./eddystone-advertisement.js":1,"./platform.js":7}],3:[function(require,module,exports){
+},{"./eddystone-advertisement.js":1,"./platform.js":8}],3:[function(require,module,exports){
 (() => {
   'use strict';
 
@@ -244,9 +293,11 @@
 
   let EddystoneURL = require('./eddystone-url.js');
   let EddystoneUID = require('./eddystone-uid.js');
+  let IBeacon = require('./ibeacon.js');
   let EddystoneAdvertisement = require('./eddystone-advertisement.js').EddystoneAdvertisement;
   const EddystoneFrameType = require('./eddystone-advertisement.js').EddystoneFrameType;
   const EDDYSTONE_UUID = require('./eddystone-advertisement.js').EDDYSTONE_UUID;
+  const IBEACON_ID = require('./eddystone-advertisement.js').IBEACON_ID;
   /**
      This class wraps the underlying ChromeOS BLE Advertising API.
      @todo Add link to API.
@@ -260,6 +311,7 @@
        @property {string} type
        @property {Array} serviceUuids
        @property {Object} serviceData {uuid: {string}, data: {number[]}}
+       @property {Object} manufacturerData {id: {int}, data: {number[]}}
      */
 
     /**
@@ -321,29 +373,41 @@
        https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url-http-url-encoding
      */
     static _constructAdvertisement(options) {
-      let data;
-      if (options.type === EddystoneFrameType.URL) {
-        data = EddystoneURL.constructServiceData(options.url, options.advertisedTxPower);
-      } else if (options.type === EddystoneFrameType.UID) {
-        data = EddystoneUID.constructServiceData(
-          options.advertisedTxPower, options.namespace, options.instance);
+      let data, advertisement;
+      if (options.type ===  EddystoneFrameType.URL || options.type === EddystoneFrameType.UID) {
+        if (options.type === EddystoneFrameType.URL) {
+          data = EddystoneURL.constructServiceData(options.url, options.advertisedTxPower);
+        } else if (options.type === EddystoneFrameType.UID) {
+          data = EddystoneUID.constructServiceData(
+            options.advertisedTxPower, options.namespace, options.instance);
+        }
+        advertisement = {
+          type: 'broadcast',
+          serviceUuids: [EDDYSTONE_UUID],
+          serviceData: [{
+            uuid: EDDYSTONE_UUID,
+            data: data
+          }]
+        };
+      } else if (options.type ===  EddystoneFrameType.IBEACON) {
+        data = IBeacon.constructManufacturerData(options.uuid, options.major, options.minor, options.advertisedTxPower);
+        advertisement = {
+          type: 'broadcast',
+          manufacturerData: [{
+            id: IBEACON_ID,
+            data: data
+          }]
+        };
       } else {
         throw new Error('Unsupported Frame Type: ' + options.type);
       }
-      return {
-        type: 'broadcast',
-        serviceUuids: [EDDYSTONE_UUID],
-        serviceData: [{
-          uuid: EDDYSTONE_UUID,
-          data: data
-        }]
-      };
+      return advertisement;
     }
   }
   module.exports = EddystoneChromeOS;
 })();
 
-},{"./eddystone-advertisement.js":1,"./eddystone-uid.js":4,"./eddystone-url.js":5}],4:[function(require,module,exports){
+},{"./eddystone-advertisement.js":1,"./eddystone-uid.js":4,"./eddystone-url.js":5,"./ibeacon.js":7}],4:[function(require,module,exports){
 (() => {
   'use strict';
 
@@ -677,6 +741,155 @@
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"./eddystone-advertising.js":2}],7:[function(require,module,exports){
+(() => {
+  'use strict';
+
+  /**
+   * @module ibeacon
+   * @typicalname ibeacon
+   */
+
+  const IBEACON_ID = require('./eddystone-advertisement.js').IBEACON_ID;
+
+  /**
+     iBeacon Frame type.
+     @private
+     @constant {number}
+     @default
+   */
+  const IBEACON_PREAMBLE = 0x0215;
+
+  const UUID_LENGTH = 16;
+  const MAJOR_MINOR_LENGTH = 2;
+
+  const HEX_REGEX = /[0-9a-f]/i;
+
+  /**
+     This class provides helper functions that relate to iBeacon.
+     @alias module:ibeacon
+   */
+  class IBeacon {
+    /**
+       Constructs a valid iBeacon manufacturer data from a Tx Power value, uuid,
+       major and minor.
+       @param {number} advertisedTxPower The Tx Power included in the service data.
+       @param {number[]|string} uuid The uuid to advertise.
+       @param {number[]|number} major The major to advertise.
+       @param {number[]|number} minor The minor to advertise.
+       @returns {number[]} The manufacturer data.
+     */
+    static constructManufacturerData(uuid, major, minor, advertisedTxPower) {
+      // Check that it's a valid Tx Power.
+      if (advertisedTxPower < -100 || advertisedTxPower > 20) {
+        throw new Error('Invalid Tx Power value: ' + advertisedTxPower + '.');
+      }
+      let base_frame = [IBEACON_PREAMBLE];
+      Array.prototype.push.apply(base_frame, IBeacon._getUuidByteArray(uuid));
+      Array.prototype.push.apply(base_frame, IBeacon._getMajorMinorByteArray(major));
+      Array.prototype.push.apply(base_frame, IBeacon._getMajorMinorByteArray(minor));
+      Array.prototype.push.apply(base_frame, [advertisedTxPower]);
+      return base_frame;
+    }
+
+    /**
+       Validates the given array of bytes or converts the hex string into an array of bytes.
+       @param {number[]|string} value The value to encode.
+       @throws {TypeError} If |value| is not an array or a string.
+       @throws {Error} If |value| contains out-of-range numbers or characters.
+       @returns {number[]} Array of bytes.
+    */
+    static getByteArray(value, expected_length) {
+      if (typeof value === 'string') {
+        // A hex string is twice as long as the byte array it represents.
+        let str_expected_length = expected_length * 2;
+        return IBeacon._encodeString(value, str_expected_length);
+      }
+      if (typeof value === 'number') {
+        return IBeacon._encodeNumber(value, expected_length);
+      }
+      if (Array.isArray(value)) {
+        return IBeacon._validateByteArray(value, expected_length);
+      }
+      throw new TypeError('Only string or array are supported');
+    }
+
+    static getHexString(bytes) {
+      let hex_string = '';
+      for (let i = 0; i < bytes.length; i++) {
+        if (bytes[i] > 0xFF) {
+          throw new Error('Invalid value \'' + bytes[i] + '\' at index ' + i + '.');
+        }
+        hex_string = hex_string.concat((bytes[i] >>> 4).toString(16));
+        hex_string = hex_string.concat((bytes[i] & 0xF).toString(16));
+      }
+      return hex_string;
+    }
+
+    static _getUuidByteArray(uuid) {
+      return IBeacon.getByteArray(uuid, UUID_LENGTH);
+    }
+
+    static _getMajorMinorByteArray(majorMinor) {
+      return IBeacon.getByteArray(majorMinor, MAJOR_MINOR_LENGTH);
+    }
+
+    static _encodeString(str, expected_length) {
+      if (expected_length % 2 !== 0) {
+        throw new Error('expected_length should be an even number.');
+      }
+      if (str.length !== expected_length) {
+        throw new Error('Expected length to be: ' + expected_length + '. ' +
+                        'But was: ' + str.length  + '. Remember a hex string is twice ' +
+                        'as long as the number of bytes desired.');
+      }
+      let bytes = [];
+      for (let i = 0; i < str.length; i += 2) {
+        if (!HEX_REGEX.test(str[i])) {
+          throw new Error('Invalid character \'' + str[i] + '\' at index ' + i);
+        }
+        if (!HEX_REGEX.test(str[i + 1])) {
+          throw new Error('Invalid character \'' + str[i + 1] + '\' at index ' + (i + 1));
+        }
+        bytes.push(parseInt(str.substr(i, 2), 16));
+      }
+      return bytes;
+    }
+
+    static _encodeNumber(num, expected_length) {
+      if (typeof num !== 'number') {
+        throw new Error('Input not a number: ' + num);
+      }
+      if (num < 0 || num > 65535) {
+        throw new Error('major and minor must be between 0 and 65535.');
+      }
+      let str;
+      // Convert number to string and pad with zeros
+      str = ('0000' + num.toString(16)).substr(-(MAJOR_MINOR_LENGTH*2));
+      // A hex string is twice as long as the byte array it represents.
+      let str_expected_length = expected_length * 2;
+      return IBeacon._encodeString(str, str_expected_length);
+    }
+
+    static _validateByteArray(arr, expected_length) {
+      if (arr.length !== expected_length) {
+        throw new Error('Expected length to be: ' + expected_length + '. ' +
+                        'But was: ' + arr.length + '.');
+      }
+      for (let i = 0; i < arr.length; i++) {
+        if (typeof arr[i] !== 'number') {
+          throw new Error('Unexpected value \'' + arr[i] + '\' at index ' + i + '.');
+        }
+        if (!(arr[i] >= 0x00 && arr[i] <= 0xFF)) {
+          throw new Error('Unexpected value \'' + arr[i] + '\' at index ' + i + '.');
+        }
+      }
+      return arr;
+    }
+  }
+  module.exports = IBeacon;
+})();
+
+},{"./eddystone-advertisement.js":1}],8:[function(require,module,exports){
 (() => {
   'use strict';
 

--- a/libraries/javascript/eddystone-advertising/eddystone-advertising.js
+++ b/libraries/javascript/eddystone-advertising/eddystone-advertising.js
@@ -38,11 +38,11 @@
   /**
      Assigned ID for iBeacon Advertisements
      @private
-     @constant {string}
+     @constant {number}
      @default
      @alias module:eddystone-advertisement.IBEACON_ID
    */
-  const IBEACON_ID = '004C';
+  const IBEACON_ID = 76;
 
   /**
      Represents the Advertisement being broadcasted.
@@ -783,11 +783,11 @@
       if (advertisedTxPower < -100 || advertisedTxPower > 20) {
         throw new Error('Invalid Tx Power value: ' + advertisedTxPower + '.');
       }
-      let base_frame = [IBEACON_PREAMBLE];
+      let base_frame = IBeacon.getByteArray(IBEACON_PREAMBLE, 2);
       Array.prototype.push.apply(base_frame, IBeacon._getUuidByteArray(uuid));
       Array.prototype.push.apply(base_frame, IBeacon._getMajorMinorByteArray(major));
       Array.prototype.push.apply(base_frame, IBeacon._getMajorMinorByteArray(minor));
-      Array.prototype.push.apply(base_frame, [advertisedTxPower]);
+      Array.prototype.push.apply(base_frame, IBeacon._getAdvertisedTxPowerArray(advertisedTxPower));
       return base_frame;
     }
 
@@ -831,6 +831,13 @@
 
     static _getMajorMinorByteArray(majorMinor) {
       return IBeacon.getByteArray(majorMinor, MAJOR_MINOR_LENGTH);
+    }
+
+    static _getAdvertisedTxPowerArray(advertisedTxPower) {
+      if (advertisedTxPower < -100 || advertisedTxPower > 20) {
+        throw new Error('Invalid Tx Power value: ' + advertisedTxPower + '.');
+      }
+      return [(advertisedTxPower + 256)];
     }
 
     static _encodeString(str, expected_length) {

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
@@ -21,7 +21,8 @@
   const EddystoneFrameType = {
     URL: 'url',
     UID: 'uid',
-    TLM: 'tlm'
+    TLM: 'tlm',
+    IBEACON: 'ibeacon'
   };
 
   /**
@@ -32,6 +33,15 @@
      @alias module:eddystone-advertisement.EDDYSTONE_UUID
    */
   const EDDYSTONE_UUID = 'FEAA';
+
+  /**
+     Assigned ID for iBeacon Advertisements
+     @private
+     @constant {string}
+     @default
+     @alias module:eddystone-advertisement.IBEACON_ID
+   */
+  const IBEACON_ID = '004C';
 
   /**
      Represents the Advertisement being broadcasted.
@@ -64,8 +74,8 @@
        */
       this.type = undefined;
       /**
-         Tx Power included in the advertisement. Only present if `type === 'url'`
-         or `type === 'uid'`.
+         Tx Power included in the advertisement. Only present if `type === 'url'`,
+         `type === 'uid'`, or `type === 'ibeacon'`.
          @type {number|undefined}
        */
       this.advertisedTxPower = undefined;
@@ -84,6 +94,21 @@
          @type {string|undefined}
       */
       this.instance = undefined;
+      /**
+         Hex string of the uuid being advertised. Only present if `type === 'ibeacon'`.
+         @type {string|undefined}
+      */
+      this.uuid = undefined;
+      /**
+         Hex string of the major being advertised. Only present if `type === 'ibeacon'`.
+         @type {string|undefined}
+      */
+      this.major = undefined;
+      /**
+         Hex string of the uuid being advertised. Only present if `type === 'ibeacon'`.
+         @type {string|undefined}
+      */
+      this.minor = undefined;
 
       if (options.type == EddystoneFrameType.URL) {
         this.id = id;
@@ -96,6 +121,13 @@
         this.advertisedTxPower = options.advertisedTxPower;
         this.namespace = options.namespace;
         this.instance = options.instance;
+      } else if (options.type == EddystoneFrameType.IBEACON) {
+        this.id = id;
+        this.type = options.type;
+        this.advertisedTxPower = options.advertisedTxPower;
+        this.uuid = options.uuid;
+        this.major = options.major;
+        this.minor = options.minor;
       } else {
         throw new Error('Unsupported Frame Type');
       }
@@ -117,4 +149,5 @@
   exports.EddystoneAdvertisement = EddystoneAdvertisement;
   exports.EddystoneFrameType = EddystoneFrameType;
   exports.EDDYSTONE_UUID = EDDYSTONE_UUID;
+  exports.IBEACON_ID = IBEACON_ID;
 })();

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
@@ -37,11 +37,11 @@
   /**
      Assigned ID for iBeacon Advertisements
      @private
-     @constant {string}
+     @constant {number}
      @default
      @alias module:eddystone-advertisement.IBEACON_ID
    */
-  const IBEACON_ID = '004C';
+  const IBEACON_ID = 76;
 
   /**
      Represents the Advertisement being broadcasted.

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-advertising.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-advertising.js
@@ -74,6 +74,8 @@
         Eddystone._checkURLOptions(options);
       } else if (options.type === EddystoneFrameType.UID) {
         Eddystone._checkUIDOptions(options);
+      } else if (options.type === EddystoneFrameType.IBEACON) {
+        Eddystone._checkIBEACONOptions(options);
       } else {
         throw new TypeError('Unsupported Frame Type: ' + options.type);
       }
@@ -103,6 +105,20 @@
       }
       if (!('instance' in options)) {
         throw new TypeError('Required member instance is undefined.');
+      }
+    }
+    static _checkIBEACONOptions(options) {
+      if (!('advertisedTxPower' in options)) {
+        throw new TypeError('Required member advertisedTxPower is undefined.');
+      }
+      if (!('uuid' in options)) {
+        throw new TypeError('Required member uuid is undefined.');
+      }
+      if (!('major' in options)) {
+        throw new TypeError('Required member major is undefined.');
+      }
+      if (!('minor' in options)) {
+        throw new TypeError('Required member minor is undefined.');
       }
     }
   }

--- a/libraries/javascript/eddystone-advertising/lib/ibeacon.js
+++ b/libraries/javascript/eddystone-advertising/lib/ibeacon.js
@@ -1,0 +1,129 @@
+(() => {
+  'use strict';
+
+  /**
+   * @module ibeacon
+   * @typicalname ibeacon
+   */
+
+  const IBEACON_ID = require('./eddystone-advertisement.js').IBEACON_ID;
+
+  /**
+     iBeacon Frame type.
+     @private
+     @constant {number}
+     @default
+   */
+  const IBEACON_PREAMBLE = 0x0215;
+
+  const UUID_LENGTH = 16;
+  const MAJOR_MINOR_LENGTH = 2;
+
+  const HEX_REGEX = /[0-9a-f]/i;
+
+  /**
+     This class provides helper functions that relate to iBeacon.
+     @alias module:ibeacon
+   */
+  class IBeacon {
+    /**
+       Constructs a valid iBeacon manufacturer data from a Tx Power value, uuid,
+       major and minor.
+       @param {number} advertisedTxPower The Tx Power included in the service data.
+       @param {number[]|string} uuid The uuidto advertise.
+       @param {number[]|string} major The major to advertise.
+       @param {number[]|string} minor The minor to advertise.
+       @returns {number[]} The manufacturer data.
+     */
+    static constructManufacturerData(uuid, major, minor, advertisedTxPower) {
+      // Check that it's a valid Tx Power.
+      if (advertisedTxPower < -100 || advertisedTxPower > 20) {
+        throw new Error('Invalid Tx Power value: ' + advertisedTxPower + '.');
+      }
+      let base_frame = [IBEACON_PREAMBLE];
+      Array.prototype.push.apply(base_frame, IBeacon._getUuidByteArray(uuid));
+      Array.prototype.push.apply(base_frame, IBeacon._getMajorMinorByteArray(major));
+      Array.prototype.push.apply(base_frame, IBeacon._getMajorMinorByteArray(minor));
+      Array.prototype.push.apply(base_frame, [advertisedTxPower]);
+      return base_frame;
+    }
+
+    /**
+       Validates the given array of bytes or converts the hex string into an array of bytes.
+       @param {number[]|string} value The value to encode.
+       @throws {TypeError} If |value| is not an array or a string.
+       @throws {Error} If |value| contains out-of-range numbers or characters.
+       @returns {number[]} Array of bytes.
+    */
+    static getByteArray(value, expected_length) {
+      if (typeof value === 'string') {
+        // A hex string is twice as long as the byte array it represents.
+        let str_expected_length = expected_length * 2;
+        return IBeacon._encodeString(value, str_expected_length);
+      }
+      if (Array.isArray(value)) {
+        return IBeacon._validateByteArray(value, expected_length);
+      }
+      throw new TypeError('Only string or array are supported');
+    }
+
+    static getHexString(bytes) {
+      let hex_string = '';
+      for (let i = 0; i < bytes.length; i++) {
+        if (bytes[i] > 0xFF) {
+          throw new Error('Invalid value \'' + bytes[i] + '\' at index ' + i + '.');
+        }
+        hex_string = hex_string.concat((bytes[i] >>> 4).toString(16));
+        hex_string = hex_string.concat((bytes[i] & 0xF).toString(16));
+      }
+      return hex_string;
+    }
+
+    static _getUuidByteArray(uuid) {
+      return IBeacon.getByteArray(uuid, UUID_LENGTH);
+    }
+
+    static _getMajorMinorByteArray(majorMinor) {
+      return IBeacon.getByteArray(majorMinor, MAJOR_MINOR_LENGTH);
+    }
+
+    static _encodeString(str, expected_length) {
+      if (expected_length % 2 !== 0) {
+        throw new Error('expected_length should be an even number.');
+      }
+      if (str.length !== expected_length) {
+        throw new Error('Expected length to be: ' + expected_length + '. ' +
+                        'But was: ' + str.length  + '. Remember a hex string is twice ' +
+                        'as long as the number of bytes desired.');
+      }
+      let bytes = [];
+      for (let i = 0; i < str.length; i += 2) {
+        if (!HEX_REGEX.test(str[i])) {
+          throw new Error('Invalid character \'' + str[i] + '\' at index ' + i);
+        }
+        if (!HEX_REGEX.test(str[i + 1])) {
+          throw new Error('Invalid character \'' + str[i + 1] + '\' at index ' + (i + 1));
+        }
+        bytes.push(parseInt(str.substr(i, 2), 16));
+      }
+      return bytes;
+    }
+
+    static _validateByteArray(arr, expected_length) {
+      if (arr.length !== expected_length) {
+        throw new Error('Expected length to be: ' + expected_length + '. ' +
+                        'But was: ' + arr.length + '.');
+      }
+      for (let i = 0; i < arr.length; i++) {
+        if (typeof arr[i] !== 'number') {
+          throw new Error('Unexpected value \'' + arr[i] + '\' at index ' + i + '.');
+        }
+        if (!(arr[i] >= 0x00 && arr[i] <= 0xFF)) {
+          throw new Error('Unexpected value \'' + arr[i] + '\' at index ' + i + '.');
+        }
+      }
+      return arr;
+    }
+  }
+  module.exports = IBeacon;
+})();

--- a/libraries/javascript/eddystone-advertising/lib/ibeacon.js
+++ b/libraries/javascript/eddystone-advertising/lib/ibeacon.js
@@ -30,9 +30,9 @@
        Constructs a valid iBeacon manufacturer data from a Tx Power value, uuid,
        major and minor.
        @param {number} advertisedTxPower The Tx Power included in the service data.
-       @param {number[]|string} uuid The uuidto advertise.
-       @param {number[]|string} major The major to advertise.
-       @param {number[]|string} minor The minor to advertise.
+       @param {number[]|string} uuid The uuid to advertise.
+       @param {number[]|number} major The major to advertise.
+       @param {number[]|number} minor The minor to advertise.
        @returns {number[]} The manufacturer data.
      */
     static constructManufacturerData(uuid, major, minor, advertisedTxPower) {
@@ -60,6 +60,9 @@
         // A hex string is twice as long as the byte array it represents.
         let str_expected_length = expected_length * 2;
         return IBeacon._encodeString(value, str_expected_length);
+      }
+      if (typeof value === 'number') {
+        return IBeacon._encodeNumber(value, expected_length);
       }
       if (Array.isArray(value)) {
         return IBeacon._validateByteArray(value, expected_length);
@@ -107,6 +110,21 @@
         bytes.push(parseInt(str.substr(i, 2), 16));
       }
       return bytes;
+    }
+
+    static _encodeNumber(num, expected_length) {
+      if (typeof num !== 'number') {
+        throw new Error('Invalid number: ' + num);
+      }
+      if (num < 0 || num > 65535) {
+        throw new Error('major and minor must be between 0 and 65535.');
+      }
+      let str;
+      // Convert number to string and pad with zeros
+      str = ("0000" + num.toString(16)).substr(-(MAJOR_MINOR_LENGTH*2));
+      // A hex string is twice as long as the byte array it represents.
+      let str_expected_length = expected_length * 2;
+      return IBeacon._encodeString(str, str_expected_length);
     }
 
     static _validateByteArray(arr, expected_length) {

--- a/libraries/javascript/eddystone-advertising/lib/ibeacon.js
+++ b/libraries/javascript/eddystone-advertising/lib/ibeacon.js
@@ -114,14 +114,14 @@
 
     static _encodeNumber(num, expected_length) {
       if (typeof num !== 'number') {
-        throw new Error('Invalid number: ' + num);
+        throw new Error('Input not a number: ' + num);
       }
       if (num < 0 || num > 65535) {
         throw new Error('major and minor must be between 0 and 65535.');
       }
       let str;
       // Convert number to string and pad with zeros
-      str = ("0000" + num.toString(16)).substr(-(MAJOR_MINOR_LENGTH*2));
+      str = ('0000' + num.toString(16)).substr(-(MAJOR_MINOR_LENGTH*2));
       // A hex string is twice as long as the byte array it represents.
       let str_expected_length = expected_length * 2;
       return IBeacon._encodeString(str, str_expected_length);

--- a/libraries/javascript/eddystone-advertising/lib/ibeacon.js
+++ b/libraries/javascript/eddystone-advertising/lib/ibeacon.js
@@ -40,11 +40,11 @@
       if (advertisedTxPower < -100 || advertisedTxPower > 20) {
         throw new Error('Invalid Tx Power value: ' + advertisedTxPower + '.');
       }
-      let base_frame = [IBEACON_PREAMBLE];
+      let base_frame = IBeacon.getByteArray(IBEACON_PREAMBLE, 2);
       Array.prototype.push.apply(base_frame, IBeacon._getUuidByteArray(uuid));
       Array.prototype.push.apply(base_frame, IBeacon._getMajorMinorByteArray(major));
       Array.prototype.push.apply(base_frame, IBeacon._getMajorMinorByteArray(minor));
-      Array.prototype.push.apply(base_frame, [advertisedTxPower]);
+      Array.prototype.push.apply(base_frame, IBeacon._getAdvertisedTxPowerArray(advertisedTxPower));
       return base_frame;
     }
 
@@ -88,6 +88,13 @@
 
     static _getMajorMinorByteArray(majorMinor) {
       return IBeacon.getByteArray(majorMinor, MAJOR_MINOR_LENGTH);
+    }
+
+    static _getAdvertisedTxPowerArray(advertisedTxPower) {
+      if (advertisedTxPower < -100 || advertisedTxPower > 20) {
+        throw new Error('Invalid Tx Power value: ' + advertisedTxPower + '.');
+      }
+      return [(advertisedTxPower + 256)];
     }
 
     static _encodeString(str, expected_length) {

--- a/libraries/javascript/eddystone-advertising/test/unit/eddystone-advertisement-unit.js
+++ b/libraries/javascript/eddystone-advertising/test/unit/eddystone-advertisement-unit.js
@@ -39,6 +39,10 @@ describe('EddystoneAdvertisement', () => {
       // UID members
       expect(adv.namespace).to.be.undefined;
       expect(adv.instance).to.be.undefined;
+      // iBeacon members
+      expect(adv.uuid).to.be.undefined;
+      expect(adv.major).to.be.undefined;
+      expect(adv.minor).to.be.undefined;
     });
     it('Check UID assignment', () => {
       let id = 100;
@@ -62,6 +66,39 @@ describe('EddystoneAdvertisement', () => {
       expect(adv.instance).to.eql(instance);
       // URL members
       expect(adv.url).to.be.undefined;
+      // iBeacon members
+      expect(adv.uuid).to.be.undefined;
+      expect(adv.major).to.be.undefined;
+      expect(adv.minor).to.be.undefined;
+    });
+    it('Check iBeacon assignment', () => {
+      let id = 100;
+      let type = 'ibeacon';
+      let tx_power = -10;
+      let uuid = [1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6];
+      let major = [1,2];
+      let minor = [1,2];
+      let adv = new EddystoneAdvertisement(
+        id, {
+          type: type,
+          advertisedTxPower: tx_power,
+          uuid: uuid,
+          major: major,
+          minor:minor
+        },
+        {} /* platform */);
+      // iBeacon members
+      expect(adv.id).to.eql(id);
+      expect(adv.type).to.eql(type);
+      expect(adv.advertisedTxPower).to.eql(tx_power);
+      expect(adv.uuid).to.eql(uuid);
+      expect(adv.major).to.eql(major);
+      expect(adv.major).to.eql(minor);
+      // URL members
+      expect(adv.url).to.be.undefined;
+      // UID members
+      expect(adv.namespace).to.be.undefined;
+      expect(adv.instance).to.be.undefined;
     });
   });
 

--- a/libraries/javascript/eddystone-advertising/test/unit/eddystone-advertising-unit.js
+++ b/libraries/javascript/eddystone-advertising/test/unit/eddystone-advertising-unit.js
@@ -171,7 +171,87 @@ describe('Eddystone', () => {
       });
     });
   });
-
+  describe('ibeacon', () => {
+    let test_uuid = '00000000000000000000000000000000';
+    let test_major = '0000';
+    let test_minor = '0000';
+    [{
+      name: 'No type, no advertisedTxPower, no uuid, no major/minor',
+      options: {},
+      errorRegex: /type|advertisedTxPower|uuid|major|minor/
+    }, {
+      name: 'No type, no advertisedTxPower, no uuid, yes major/minor',
+      options: {major: test_major, minor: test_minor},
+      errorRegex: /type|advertisedTxPower|uuid/
+    }, {
+      name: 'No type, no advertisedTxPower, yes uuid, no major/minor',
+      options: {uuid: test_uuid},
+      errorRegex: /type|advertisedTxPower|major|minor/
+    }, {
+      name: 'No type, no advertisedTxPower, yes uuid, yes major/minor',
+      options: {uuid: test_uuid, major: test_major, minor: test_minor},
+      errorRegex: /type|advertisedTxPower/
+    }, {
+      name: 'No type, yes advertisedTxPower, no uuid, no major/minor',
+      options: {advertisedTxPower: -10},
+      errorRegex: /type|uuid|major|minor/
+    }, {
+      name: 'No type, yes advertisedTxPower, no uuid, yes major/minor',
+      options: {advertisedTxPower: -10, major: test_major, minor: test_minor},
+      errorRegex: /type|uuid/
+    }, {
+      name: 'No type, yes advertisedTxPower, yes uuid, no major/minor',
+      options: {advertisedTxPower: -10, uuid: test_uuid},
+      errorRegex: /type|major|minor/
+    }, {
+      name: 'No type, yes advertisedTxPower, yes uuid, yes major/minor',
+      options: {advertisedTxPower: -10, uuid: test_uuid,
+                major: test_major, minor: test_minor},
+      errorRegex: /type/
+    }, {
+      name: 'Yes type, no advertisedTxPower, no uuid, no major/minor',
+      options: {type: 'ibeacon'},
+      errorRegex: /advertisedTxPower|uuid|major|minor/
+    }, {
+      name: 'Yes type, no advertisedTxPower, no uuid, yes major/minor',
+      options: {type: 'ibeacon', major: test_major, minor: test_minor},
+      errorRegex: /advertisedTxPower|uuid/
+    }, {
+      name: 'Yes type, no advertisedTxPower, yes uuid, no major/minor',
+      options: {type: 'ibeacon',uuid: test_uuid},
+      errorRegex: /advertisedTxPower|major|minor/
+    }, {
+      name: 'Yes type, no advertisedTxPower, yes uuid, yes major/minor',
+      options: {type: 'ibeacon', uuid: test_uuid,
+                major: test_major, minor: test_minor},
+      errorRegex: /advertisedTxPower/
+    }, {
+      name: 'Yes type, yes advertisedTxPower, no uuid, no major/minor',
+      options: {type: 'ibeacon', advertisedTxPower: -10},
+      errorRegex: /uuid|major|minor/
+    }, {
+      name: 'Yes type, yes advertisedTxPower, no uuid, yes major/minor',
+      options: {type: 'ibeacon', advertisedTxPower: -10,
+                major: test_major, minor: test_minor},
+      errorRegex: /uuid/
+    }, {
+      name: 'Yes type, yes advertisedTxPower, yes uuid, no major/minor',
+      options: {type: 'ibeacon', advertisedTxPower: -10,
+                uuid: test_uuid},
+      errorRegex: /major|minor/
+    }].forEach(test => {
+      it(test.name, () => {
+        expect(() => Eddystone._checkAdvertisementOptions(test.options))
+          .to.throw(TypeError, test.errorRegex);
+      });
+    });
+    it('Yes type, yes advertisedTxPower, yes namespace, yes major/minor', () => {
+      expect(() => Eddystone._checkAdvertisementOptions({
+        type: 'ibeacon', advertisedTxPower: -10,
+        uuid: test_uuid, major: test_major, minor: test_minor
+      })).to.not.throw();
+    });
+  });
   describe('registerAdvertisement()', () => {
     let options = {
       type: 'url',

--- a/libraries/javascript/eddystone-advertising/test/unit/eddystone-chrome-os-unit.js
+++ b/libraries/javascript/eddystone-advertising/test/unit/eddystone-chrome-os-unit.js
@@ -105,17 +105,17 @@ describe('EddystoneChromeOS', () => {
           type: 'ibeacon',
           advertisedTxPower: -10,
           uuid: '12345678901234567890123456789012',
-          major: '0000',
-          minor: '0000'
+          major: 65535,
+          minor: 65535
         }));
       });
       it('Invalid iBeacon', () => {
         expect(() => EddystoneChromeOS._constructAdvertisement({
           type: 'ibeacon',
           advertisedTxPower: -10,
-          uuid: 'GGG',
-          major: 'GGG',
-          minor: 'GGG',
+          uuid: '12345678901234567890123456789012',
+          major: 70000,
+          minor: 70000,
         })).to.throw(Error);
       });
     });

--- a/libraries/javascript/eddystone-advertising/test/unit/eddystone-chrome-os-unit.js
+++ b/libraries/javascript/eddystone-advertising/test/unit/eddystone-chrome-os-unit.js
@@ -21,6 +21,8 @@ describe('EddystoneChromeOS', () => {
                                       .not.to.throw(/Unsupported Frame Type/);
         expect(() => EddystoneChromeOS._constructAdvertisement({type: 'uid'}))
                                       .not.to.throw(/Unsupported Frame Type/);
+        expect(() => EddystoneChromeOS._constructAdvertisement({type: 'ibeacon'}))
+                                      .not.to.throw(/Unsupported Frame Type/);
         expect(() => EddystoneChromeOS._constructAdvertisement({type: 'tlm'}))
                                       .to.throw(Error, /Unsupported Frame Type/);
         expect(() => EddystoneChromeOS._constructAdvertisement({}))
@@ -94,6 +96,26 @@ describe('EddystoneChromeOS', () => {
           advertisedTxPower: -10,
           namespace: 'GGG',
           instance: 'GGG'
+        })).to.throw(Error);
+      });
+    });
+    describe('iBeacon', () => {
+      it('Valid iBeacon', () => {
+        expect(EddystoneChromeOS._constructAdvertisement({
+          type: 'ibeacon',
+          advertisedTxPower: -10,
+          uuid: '12345678901234567890123456789012',
+          major: '0000',
+          minor: '0000'
+        }));
+      });
+      it('Invalid iBeacon', () => {
+        expect(() => EddystoneChromeOS._constructAdvertisement({
+          type: 'ibeacon',
+          advertisedTxPower: -10,
+          uuid: 'GGG',
+          major: 'GGG',
+          minor: 'GGG',
         })).to.throw(Error);
       });
     });

--- a/libraries/javascript/eddystone-advertising/test/unit/eddystone-chrome-os-unit.js
+++ b/libraries/javascript/eddystone-advertising/test/unit/eddystone-chrome-os-unit.js
@@ -103,7 +103,7 @@ describe('EddystoneChromeOS', () => {
       it('Valid iBeacon', () => {
         expect(EddystoneChromeOS._constructAdvertisement({
           type: 'ibeacon',
-          advertisedTxPower: -10,
+          advertisedTxPower: -59,
           uuid: '12345678901234567890123456789012',
           major: 65535,
           minor: 65535
@@ -112,7 +112,7 @@ describe('EddystoneChromeOS', () => {
       it('Invalid iBeacon', () => {
         expect(() => EddystoneChromeOS._constructAdvertisement({
           type: 'ibeacon',
-          advertisedTxPower: -10,
+          advertisedTxPower: -59,
           uuid: '12345678901234567890123456789012',
           major: 70000,
           minor: 70000,

--- a/libraries/javascript/eddystone-advertising/test/unit/ibeacon-unit.js
+++ b/libraries/javascript/eddystone-advertising/test/unit/ibeacon-unit.js
@@ -70,6 +70,14 @@ describe('IBeacon', () => {
       expect(() => IBeacon._getMajorMinorByteArray([1])).to.throw(Error);
     });
   });
+  describe('_getAdvertisedTxPowerArray()', () => {
+    it('Correct Advertised Tx Power', () => {
+      expect(IBeacon._getAdvertisedTxPowerArray(-59)).to.eql([197]);
+    });
+    it('Invalid Advertised Tx Power', () => {
+      expect(() => IBeacon._getAdvertisedTxPowerArray(100)).to.throw(Error);
+    });
+  });
   describe('_encodeString()', () => {
     it('Odd expected length', () => {
       expect(() => IBeacon._encodeString('012', 3)).to.throw(/length/);

--- a/libraries/javascript/eddystone-advertising/test/unit/ibeacon-unit.js
+++ b/libraries/javascript/eddystone-advertising/test/unit/ibeacon-unit.js
@@ -106,7 +106,7 @@ describe('IBeacon', () => {
     it('Valid Number', () => {
       expect(IBeacon._encodeNumber(1, 2)).eql([0, 0x01]);
     });
-  })
+  });
   describe('_validateByteArray()', () => {
     it('Too long array', () => {
       expect(() => IBeacon._validateByteArray([1,2,3], 2)).to.throw(/length/);

--- a/libraries/javascript/eddystone-advertising/test/unit/ibeacon-unit.js
+++ b/libraries/javascript/eddystone-advertising/test/unit/ibeacon-unit.js
@@ -1,0 +1,101 @@
+// jshint node: true
+// We need this so chai `expect` statements don't throw an error.
+// jshint expr: true
+'use strict';
+
+import chai, {expect} from 'chai';
+import IBeacon from '../../lib/ibeacon.js';
+
+describe('IBeacon', () => {
+  describe('getByteArray()', () => {
+    it('Invalid type', () => {
+      expect(() => IBeacon.getByteArray({}, 5)).to.throw(TypeError);
+    });
+    it('Valid String', () => {
+      expect(IBeacon.getByteArray('FF00', 2)).to.eql([0xFF, 0]);
+    });
+    it('Invalid String', () => {
+      expect(() => IBeacon.getByteArray('GGGG', 2)).to.throw(Error);
+    });
+    it('Valid byte array', () => {
+      expect(IBeacon.getByteArray([1, 2, 3, 4], 4)).to.eql([1, 2, 3, 4]);
+    });
+    it('Invalid byte array', () => {
+      expect(() => IBeacon.getByteArray([0xF00], 1)).to.throw(Error);
+    });
+  });
+  describe('getHexString()', () => {
+    it('Valid String', () => {
+      expect(IBeacon.getHexString([0xFF])).to.eql('ff');
+    });
+    it('Invalid String', () => {
+      expect(() => IBeacon.getHexString([0xF00])).to.throw(Error);
+    });
+  });
+  describe('_getUuidByteArray()', () => {
+    it('Valid String UUID', () => {
+      expect(IBeacon._getUuidByteArray('0102030405060708090a0b0c0d0e0f10'))
+        .to.eql([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]);
+    });
+    it('Invalid Length String UUID', () => {
+      expect(() => IBeacon._getUuidByteArray('0102030405'))
+        .to.throw(Error);
+    });
+    it('Valid Byte UUID', () => {
+      expect(IBeacon._getUuidByteArray([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6]))
+        .to.eql([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6]);
+    });
+    it('Invalid Length Byte UUID', () => {
+      expect(() => IBeacon._getUuidByteArray([1,2,3,4]))
+        .to.throw(Error);
+    });
+  });
+  describe('_getMajorMinorByteArray()', () => {
+    it('Valid String Major/Minor', () => {
+      expect(IBeacon._getMajorMinorByteArray('0102')).to.eql([1,2]);
+    });
+    it('Invalid Length String Major/Minor', () => {
+      expect(() => IBeacon._getMajorMinorByteArray('01')).to.throw(Error);
+    });
+    it('Valid Byte Array Major/Minor', () => {
+      expect(IBeacon._getMajorMinorByteArray([1,2])).to.eql([1,2]);
+    });
+    it('Invalid Length Byte Array Major/Minor', () => {
+      expect(() => IBeacon._getMajorMinorByteArray([1])).to.throw(Error);
+    });
+  });
+  describe('_encodeString()', () => {
+    it('Odd expected length', () => {
+      expect(() => IBeacon._encodeString('012', 3)).to.throw(/length/);
+    });
+    it('Too Long String', () => {
+      expect(() => IBeacon._encodeString('010203', 4)).to.throw(/length/);
+    });
+    it('Too Short String', () => {
+      expect(() => IBeacon._encodeString('01', 4)).to.throw(/length/);
+    });
+    it('Correct Length String', () => {
+      expect(IBeacon._encodeString('0102', 4)).to.eql([1,2]);
+    });
+    it('Invalid characters String', () => {
+      expect(() => IBeacon._encodeString('010G', 4)).to.throw(/character/);
+    });
+    it('Valid String', () => {
+      expect(IBeacon._encodeString('abcdef', 6)).eql([0xab, 0xcd, 0xef]);
+    });
+  });
+  describe('_validateByteArray()', () => {
+    it('Too long array', () => {
+      expect(() => IBeacon._validateByteArray([1,2,3], 2)).to.throw(/length/);
+    });
+    it('Too short array', () => {
+      expect(() => IBeacon._validateByteArray([1], 2)).to.throw(/length/);
+    });
+    it('Wrong type in array', () => {
+      expect(() => IBeacon._validateByteArray([1, {}], 2)).to.throw(/value/);
+    });
+    it('Wrong value in array', () => {
+      expect(() => IBeacon._validateByteArray([1, 0xF00], 2)).to.throw(/value/);
+    });
+  });
+});

--- a/libraries/javascript/eddystone-advertising/test/unit/ibeacon-unit.js
+++ b/libraries/javascript/eddystone-advertising/test/unit/ibeacon-unit.js
@@ -17,6 +17,12 @@ describe('IBeacon', () => {
     it('Invalid String', () => {
       expect(() => IBeacon.getByteArray('GGGG', 2)).to.throw(Error);
     });
+    it('Valid Number', () => {
+      expect(IBeacon.getByteArray(1, 2)).to.eql([0, 0x01]);
+    });
+    it('Invalid Number', () => {
+      expect(() => IBeacon.getByteArray(65536, 2)).to.throw(Error);
+    });
     it('Valid byte array', () => {
       expect(IBeacon.getByteArray([1, 2, 3, 4], 4)).to.eql([1, 2, 3, 4]);
     });
@@ -51,11 +57,11 @@ describe('IBeacon', () => {
     });
   });
   describe('_getMajorMinorByteArray()', () => {
-    it('Valid String Major/Minor', () => {
-      expect(IBeacon._getMajorMinorByteArray('0102')).to.eql([1,2]);
+    it('Valid Number Major/Minor', () => {
+      expect(IBeacon._getMajorMinorByteArray(1)).to.eql([0,1]);
     });
-    it('Invalid Length String Major/Minor', () => {
-      expect(() => IBeacon._getMajorMinorByteArray('01')).to.throw(Error);
+    it('Invalid Number Major/Minor', () => {
+      expect(() => IBeacon._getMajorMinorByteArray(-1)).to.throw(Error);
     });
     it('Valid Byte Array Major/Minor', () => {
       expect(IBeacon._getMajorMinorByteArray([1,2])).to.eql([1,2]);
@@ -84,6 +90,23 @@ describe('IBeacon', () => {
       expect(IBeacon._encodeString('abcdef', 6)).eql([0xab, 0xcd, 0xef]);
     });
   });
+  describe('_encodeNumber()', () => {
+    it('Too Large Number', () => {
+      expect(() => IBeacon._encodeNumber(65536, 2)).to.throw(/major/);
+    });
+    it('Too Small Number', () => {
+      expect(() => IBeacon._encodeNumber(-1, 2)).to.throw(/major/);
+    });
+    it('Correct Number', () => {
+      expect(IBeacon._encodeNumber(65535, 2)).to.eql([0xff,0xff]);
+    });
+    it('Invalid characters Number', () => {
+      expect(() => IBeacon._encodeNumber('string', 2)).to.throw(/number/);
+    });
+    it('Valid Number', () => {
+      expect(IBeacon._encodeNumber(1, 2)).eql([0, 0x01]);
+    });
+  })
   describe('_validateByteArray()', () => {
     it('Too long array', () => {
       expect(() => IBeacon._validateByteArray([1,2,3], 2)).to.throw(/length/);


### PR DESCRIPTION
This adds a new iBeacon advertisement type to the Eddystone advertising library for Chrome OS.  This example shows how to broadcast an iBeacon advertisement:

```
let registered_adv;
  eddystone.registerAdvertisement({
    type: 'ibeacon',
    advertisedTxPower: -59,
    uuid: '2F234454CF6D4A0FADF2F4911BA9FFA6',
    major: 1,
    minor: 1
  })
  .then(function(advertisement) {
    registered_adv = advertisement;
  })
  .catch(function(error) {
    console.warn('Advertising Error: ' + error.message);
  });
```

I know it seems weird to create an iBeacon advertisement by calling `eddystone.registerAdvertisement()` with type `ibeacon`, but this was the quickest way to add iBeacon to Chrome OS by leveraging the existing library.  I'm open to different ideas moving forward, but this proves it can be done.
